### PR TITLE
Use pprof with serialized profiling session

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -91,6 +91,7 @@ overwriting the output file. `PProf.kill()` will kill the server.
 """
 function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                period::Union{Nothing, UInt64} = nothing;
+               lookup::Union{Nothing, Dict{UInt,Array{StackFrame,1}}} = nothing,
                web::Bool = true,
                webhost::AbstractString = "localhost",
                webport::Integer = 57599,
@@ -101,7 +102,9 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
     if data === nothing
         data = copy(Profile.fetch())
     end
-    lookup = Profile.getdict(data)
+    if lookup === nothing
+        lookup = Profile.getdict(data)
+    end
     if period === nothing
         period = ccall(:jl_profile_delay_nsec, UInt64, ())
     end


### PR DESCRIPTION
If i'm not mistaken, `Profile.getdict(data)` should only work in the same process that the profiler was running.
In order to visualize a serialized session, one will need to pass in the lookup table as well!
(still need to test this, but didn't want this edit to get lost)