### PR TITLE
Add support for directly displaying FlameGraphs.jl graphs.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.
 version = "1.1.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 pprof_jll = "cf2c5f97-e748-59fa-a03f-dda3c62118cb"
 
 [compat]
+FlameGraphs = "0.2"
 OrderedCollections = "1.1"
 ProtoBuf = "0.7, 0.8"
 julia = "1.3"

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -270,7 +270,7 @@ function refresh(; webhost::AbstractString = "localhost",
 
     relative_percentages_flag = ui_relative_percentages ? "-relative_percentages" : ""
 
-    proc[] = pprof_jll.pprof() do pprof_path 
+    proc[] = pprof_jll.pprof() do pprof_path
         open(pipeline(`$pprof_path -http=$webhost:$webport $relative_percentages_flag $file`))
     end
 end
@@ -300,5 +300,7 @@ macro pprof(ex)
         $(@__MODULE__).pprof()
     end)
 end
+
+include("flamegraphs.jl")
 
 end # module

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -1,0 +1,147 @@
+import AbstractTrees
+using FlameGraphs
+
+using FlameGraphs: Node, NodeData
+using Base.StackTraces: StackFrame
+using Profile: StackFrameTree
+
+function pprof(fg::Node{NodeData},
+    period::Union{Nothing, UInt64} = nothing;
+    web::Bool = true,
+    webhost::AbstractString = "localhost",
+    webport::Integer = 57599,
+    out::AbstractString = "profile.pb.gz",
+    from_c::Bool = true,
+    drop_frames::Union{Nothing, AbstractString} = nothing,
+    keep_frames::Union{Nothing, AbstractString} = nothing,
+    ui_relative_percentages::Bool = true,
+)
+    if period === nothing
+        period = ccall(:jl_profile_delay_nsec, UInt64, ())
+    end
+    @assert !isempty(basename(out)) "`out=` must specify a file path to write to. Got unexpected: '$out'"
+    if !endswith(out, ".pb.gz")
+        out = "$out.pb.gz"
+        @info "Writing output to $out"
+    end
+
+    string_table = OrderedDict{AbstractString, Int64}()
+    enter!(string) = _enter!(string_table, string)
+    enter!(::Nothing) = _enter!(string_table, "nothing")
+    ValueType!(_type, unit) = ValueType(_type = enter!(_type), unit = enter!(unit))
+
+    function _register_function(funcs, linfo, frame)
+        id = objectid(linfo)
+
+        # Known function
+        haskey(funcs, id) && return
+
+        # Store the function in our functions dict
+        funcProto = Function()
+        funcProto.id = id
+        file = nothing
+        if linfo !== nothing && linfo isa Core.MethodInstance
+            meth = linfo.def
+            file = string(meth.file)
+            funcProto.name       = enter!(string(meth.module, ".", meth.name))
+            funcProto.start_line = convert(Int64, meth.line)
+        else
+            # frame.linfo either nothing or CodeInfo, either way fallback
+            file = string(frame.file)
+            funcProto.name = enter!(string(frame.func))
+            funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
+        end
+        file = Base.find_source_file(file)
+        funcProto.filename   = enter!(file)
+        funcProto.system_name = funcProto.name
+        # Only keep C functions if from_c=true
+        if (from_c || !frame.from_c)
+            funcs[id] = funcProto
+        end
+    end
+
+    # Setup:
+    enter!("")  # NOTE: pprof requires first entry to be ""
+    # Functions need a uid, we'll use the pointer for the method instance
+    seen_funcs = Set{UInt64}()
+    funcs = Dict{UInt64, Function}()
+
+    seen_locs = Set{UInt64}()
+    locs  = Dict{UInt64, Location}()
+    locs_from_c  = Dict{UInt64, Bool}()
+
+    sample_type = [
+        ValueType!("cpu",      "nanoseconds"), # Mandatory
+    ]
+
+    prof = PProfile(
+        sample = [], location = [], _function = [],
+        mapping = [], string_table = [],
+        sample_type = sample_type, default_sample_type = 1, # events
+        period = period, period_type = ValueType!("cpu", "nanoseconds")
+    )
+
+    if drop_frames !== nothing
+        prof.drop_frames = enter!(drop_frames)
+    end
+    if keep_frames !== nothing
+        prof.keep_frames = enter!(keep_frames)
+    end
+
+    # start decoding backtraces
+    lastwaszero = true
+
+    for leaf in AbstractTrees.Leaves(fg)
+
+        location_id = Vector{Any}()
+
+        node = leaf
+        while node.parent != node
+            data = node.data
+
+            if data.sf.from_c
+                # TODO
+                node = node.parent
+                continue
+            end
+
+            # For non-C functions, use linfo as the location id
+            linfo = data.sf.linfo
+            id = objectid(linfo)
+            location = Location(;id = id, address = id, line=[])
+            push!(location_id, id)
+            locs[id] = location
+
+            _register_function(funcs, linfo, data.sf)
+            push!(location.line, Line(function_id = id, line = data.sf.line))
+
+            node = node.parent
+        end
+
+        value = [
+            length(leaf.data.span), # time duration (nanoseconds?)
+        ]
+        push!(prof.sample, Sample(;location_id = location_id, value = value))
+
+    end
+
+    # Build Profile
+    prof.string_table = collect(keys(string_table))
+    # If from_c=false funcs and locs should NOT contain C functions
+    prof._function = collect(values(funcs))
+    prof.location  = collect(values(locs))
+
+    # Write to disk
+    open(out, "w") do io
+        writeproto(io, prof)
+    end
+
+    if web
+        refresh(webhost = webhost, webport = webport, file = out,
+            ui_relative_percentages = ui_relative_percentages)
+    end
+
+    out
+end
+
+

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -140,7 +140,7 @@ function pprof(fg::Node{NodeData},
         # Walk back up the callstack, collecting all stack traces along the way, building
         # up a stack trace for this span.
         node = leaf
-        while node.parent != node
+        while true  # do-while node.parent === node    -- this makes sure we get the top node.
             data = node.data
 
             if !from_c && data.sf.from_c
@@ -166,6 +166,10 @@ function pprof(fg::Node{NodeData},
 
             _register_function(funcs, func_id, linfo, frame)
             push!(location.line, Line(function_id = func_id, line = frame.line))
+
+            if node.parent === node
+                break
+            end
 
             node = node.parent
         end

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -73,7 +73,7 @@ function pprof(fg::Node{NodeData},
     locs_from_c  = Dict{UInt64, Bool}()
 
     sample_type = [
-        ValueType!("cpu",      "nanoseconds"), # Mandatory
+        ValueType!("events", "count"), # Mandatory
     ]
 
     prof = PProfile(

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -175,7 +175,7 @@ function pprof(fg::Node{NodeData},
         end
 
         value = [
-            length(span), # time duration (nanoseconds?)
+            length(span), # Number of samples in this frame.
         ]
         push!(prof.sample, Sample(;location_id = location_id, value = value))
 
@@ -201,5 +201,4 @@ function pprof(fg::Node{NodeData},
 
     out
 end
-
 

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -41,13 +41,15 @@ function pprof(fg::Node{NodeData},
         if linfo !== nothing && linfo isa Core.MethodInstance
             meth = linfo.def
             file = string(meth.file)
-            funcProto.name       = enter!(string(meth.module, ".", meth.name))
+            # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
+            funcProto.name       = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
             funcProto.start_line = convert(Int64, meth.line)
         else
             # frame.linfo either nothing or CodeInfo, either way fallback
             # (This could be because we are `from_c`)
             file = string(frame.file)
-            funcProto.name = enter!(string(frame.func))
+            # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
+            funcProto.name = enter!(repr(string(frame.func))[2:end-1])
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
         end
         file = Base.find_source_file(file)

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -41,15 +41,13 @@ function pprof(fg::Node{NodeData},
         if linfo !== nothing && linfo isa Core.MethodInstance
             meth = linfo.def
             file = string(meth.file)
-            # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
-            funcProto.name       = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
+            funcProto.name       = enter!(string(meth.module, ".", meth.name))
             funcProto.start_line = convert(Int64, meth.line)
         else
             # frame.linfo either nothing or CodeInfo, either way fallback
             # (This could be because we are `from_c`)
             file = string(frame.file)
-            # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
-            funcProto.name = enter!(repr(string(frame.func))[2:end-1])
+            funcProto.name = enter!(string(frame.func))
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
         end
         file = Base.find_source_file(file)

--- a/test/PProf.jl
+++ b/test/PProf.jl
@@ -18,7 +18,9 @@ end
 @testset "empty output" begin
     Profile.clear()
     # Function doesn't error if no Profile recorded
+    rm(out, force=true)
     @test (pprof(out=out, web=false); true)
+    @test ispath(out)
 end
 
 @testset "export basic profile" begin

--- a/test/flamegraphs.jl
+++ b/test/flamegraphs.jl
@@ -1,0 +1,88 @@
+module PProfFlameGraphsTest
+
+using PProf
+
+using Test
+using Profile
+using ProtoBuf
+
+# Test interactions with FlameGraphs package
+using FlameGraphs
+
+const out = tempname() * ".pb.gz"
+
+function foo(n, a, out=[])
+    # make this expensive to ensure it's sampled
+    for i in 1:n
+        push!(out, i*a)
+    end
+end
+
+@testset "empty output" begin
+    Profile.clear()
+    # Function doesn't error if no Profile recorded
+    fg = flamegraph()
+    rm(out, force=true)
+    @test (pprof(fg, out=out, web=false); true)
+    @test ispath(out)
+end
+
+@testset "export basic profile" begin
+    Profile.clear()
+
+    let x = 1
+        @profile for _ in 1:10000; x += 1; end
+        sleep(2)
+    end
+
+    # Collect the profile via FlameGraphs
+    fg = flamegraph()
+
+    # Write the profile
+    outf = pprof(fg, out=out, web=false)
+
+    # Read the exported profile
+    fg_prof = open(io->readproto(io, PProf.perftools.profiles.Profile()), outf, "r")
+
+    # Verify that we exported stack trace samples:
+    @test length(fg_prof.sample) > 0
+    # Verify that we exported frame information
+    @test length(fg_prof.location) > 0
+    @test length(fg_prof._function) > 0
+
+end
+
+function load_prof_proto(file)
+    @show file
+    open(io->readproto(io, PProf.perftools.profiles.Profile()), file, "r")
+end
+
+@testset "with_c" begin
+    Profile.clear()
+
+    let arr = []
+        @profile foo(1000000, 5, arr)
+        sleep(2)
+    end
+
+    fg = flamegraph(C=true)
+
+    # Write a profile that includes C function frames
+    with_c = load_prof_proto(pprof(fg, out=tempname(), web=false, from_c = true))
+
+    # Write a profile that excludes C function frames
+    without_c = load_prof_proto(pprof(fg, out=tempname(), web=false, from_c = false))
+
+    # Test that C frames were excluded
+    @test length(with_c.sample) == length(without_c.sample)
+    @test length(with_c.location) > length(without_c.location)
+    @test length(with_c._function) > length(without_c._function)
+end
+
+@testset "drop_frames/keep_frames" begin
+    fg = flamegraph()
+    @test load_prof_proto(pprof(fg, out=tempname(), web=false, drop_frames = "foo")).drop_frames != 0
+    @test load_prof_proto(pprof(fg, out=tempname(), web=false, keep_frames = "foo")).keep_frames != 0
+end
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,7 @@ using Test
 @testset "PProf.jl" begin
     include("PProf.jl")
 end
+
+@testset "flamegraphs.jl" begin
+    include("flamegraphs.jl")
+end


### PR DESCRIPTION
Add support for directly displaying FlameGraphs.jl graphs.

This makes PProf fit into the standard julia profiling infrastructure.

For example:

```julia
julia> using Profile, FlameGraphs, PProf, Serialization

julia> @profile peakflops()
1.1991880148053252e11

julia> fg = FlameGraphs.flamegraph()
Node(FlameGraphs.NodeData(ip:0x0, 0x00, 1:670))

julia> pprof(webport=11111, fg)
"profile.pb.gz"

julia> Main binary filename not available.
Serving web UI on http://localhost:11111
```

<img width="1326" alt="Screen Shot 2020-10-05 at 11 14 45 PM" src="https://user-images.githubusercontent.com/1582097/95154792-a7e52800-0760-11eb-91d8-0683478ec740.png">

Unfortunately, PProf doesn't retain the ordering information that the FlameGraphs have, so it's not as good of a format for FlameGraphs directly.

But the graph view and source views are still useful, even when building from FlameGraphs.
