### PR TITLE
Add optional `lidict` param to `pprof()` to support exported Profile data

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -52,7 +52,7 @@ using Base.StackTraces: StackFrame
     pprof([data, [lidict]];
             web = true, webhost = "localhost", webport = 57599,
             out = "profile.pb.gz", from_c = true, drop_frames = "", keep_frames = "",
-            ui_relative_percentages = true,
+            ui_relative_percentages = true, sampling_delay = nothing,
          )
 
 Fetches the collected `Profile` data, exports to the `pprof` format, and (optionally) opens

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -81,6 +81,7 @@ overwriting the output file. `PProf.kill()` will kill the server.
   ignored/hidden through the web UI to be ignored from totals when computing percentages.
 """
 function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
+               lidict::Union{Nothing, Dict} = nothing,
                period::Union{Nothing, UInt64} = nothing;
                web::Bool = true,
                webhost::AbstractString = "localhost",
@@ -94,7 +95,10 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
     if data === nothing
         data = copy(Profile.fetch())
     end
-    lookup = Profile.getdict(data)
+    lookup = lidict
+    if lookup === nothing
+        lookup = Profile.getdict(data)
+    end
     if period === nothing
         period = ccall(:jl_profile_delay_nsec, UInt64, ())
     end

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -49,7 +49,7 @@ using Base.StackTraces: StackFrame
 # - Mappings
 
 """
-    pprof(data, period;
+    pprof([data, [lidict]];
             web = true, webhost = "localhost", webport = 57599,
             out = "profile.pb.gz", from_c = true, drop_frames = "", keep_frames = "",
             ui_relative_percentages = true,
@@ -64,11 +64,16 @@ the web-server to use the new output.
 If you manually edit the output file, `PProf.refresh()` will refresh the server without
 overwriting the output file. `PProf.kill()` will kill the server.
 
+You can also use `PProf.refresh(file="...")` to open a new file in the server.
+
 # Arguments:
-- `data::Vector{UInt}`: The data provided by `Profile.fetch` [optional].
-- `period::UInt64`: The sampling period in nanoseconds [optional].
+- `data::Vector{UInt}`: The data provided by `Profile.retrieve()` [optional].
+- `lidict::Dict`: The lookup dictionary provided by `Profile.retrieve()` [optional].
+    - Note that you need both the `data` and the `lidict` returned from
+      `Profile.retrieve()` in order to export profiling data between julia processes.
 
 # Keyword Arguments
+- `sampling_delay::UInt64`: The period between samples in nanoseconds [optional].
 - `web::Bool`: Whether to launch the `go tool pprof` interactive webserver for viewing results.
 - `webhost::AbstractString`: If using `web`, which host to launch the webserver on.
 - `webport::Integer`: If using `web`, which port to launch the webserver on.
@@ -81,8 +86,8 @@ overwriting the output file. `PProf.kill()` will kill the server.
   ignored/hidden through the web UI to be ignored from totals when computing percentages.
 """
 function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
-               lidict::Union{Nothing, Dict} = nothing,
-               period::Union{Nothing, UInt64} = nothing;
+               lidict::Union{Nothing, Dict} = nothing;
+               sampling_delay::Union{Nothing, UInt64} = nothing,
                web::Bool = true,
                webhost::AbstractString = "localhost",
                webport::Integer = 57599,
@@ -99,8 +104,8 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
     if lookup === nothing
         lookup = Profile.getdict(data)
     end
-    if period === nothing
-        period = ccall(:jl_profile_delay_nsec, UInt64, ())
+    if sampling_delay === nothing
+        sampling_delay = ccall(:jl_profile_delay_nsec, UInt64, ())
     end
     @assert !isempty(basename(out)) "`out=` must specify a file path to write to. Got unexpected: '$out'"
     if !endswith(out, ".pb.gz")
@@ -132,7 +137,7 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
         sample = [], location = [], _function = [],
         mapping = [], string_table = [],
         sample_type = sample_type, default_sample_type = 1, # events
-        period = period, period_type = ValueType!("cpu", "nanoseconds")
+        period = sampling_delay, period_type = ValueType!("cpu", "nanoseconds")
     )
 
     if drop_frames !== nothing

--- a/test/PProf.jl
+++ b/test/PProf.jl
@@ -60,18 +60,26 @@ end
         @profile foo(1000000, 5, arr)
         sleep(2)
     end
-    data = Profile.fetch()
+    for i in 1:2
+        if i == 1
+            data = Profile.fetch()
+            args = (data,)
+        else
+            data,lidict = Profile.retrieve()
+            args = (data, lidict)
+        end
 
-    # Write a profile that includes C function frames
-    with_c = load_prof_proto(pprof(data, out=tempname(), web=false, from_c = true))
+        # Write a profile that includes C function frames
+        with_c = load_prof_proto(pprof(args..., out=tempname(), web=false, from_c = true))
 
-    # Write a profile that excludes C function frames
-    without_c = load_prof_proto(pprof(data, out=tempname(), web=false, from_c = false))
+        # Write a profile that excludes C function frames
+        without_c = load_prof_proto(pprof(args..., out=tempname(), web=false, from_c = false))
 
-    # Test that C frames were excluded
-    @test length(with_c.sample) == length(without_c.sample)
-    @test length(with_c.location) > length(without_c.location)
-    @test length(with_c._function) > length(without_c._function)
+        # Test that C frames were excluded
+        @test length(with_c.sample) == length(without_c.sample)
+        @test length(with_c.location) > length(without_c.location)
+        @test length(with_c._function) > length(without_c._function)
+    end
 end
 
 @testset "drop_frames/keep_frames" begin


### PR DESCRIPTION
From the Profile docs:
https://docs.julialang.org/en/v1/stdlib/Profile/#Profile.retrieve
> "Exports" profiling results in a portable format, returning the set of all backtraces
(`data`) and a dictionary that maps the (session-specific) instruction pointers in `data` to
`LineInfo` values that store the file name, function name, and line number. This function
allows you to save profiling results for future analysis.

You need _both_ `data` _and_ `linfo` to reuse a profile from a different process, and we currently don't support passing in the `linfo`.

So this PR fixes that.