### PR TITLE
Simplify at-pprof macro to try to fix build on julia nightly

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -270,7 +270,7 @@ function refresh(; webhost::AbstractString = "localhost",
 
     relative_percentages_flag = ui_relative_percentages ? "-relative_percentages" : ""
 
-    proc[] = pprof_jll.pprof() do pprof_path 
+    proc[] = pprof_jll.pprof() do pprof_path
         open(pipeline(`$pprof_path -http=$webhost:$webport $relative_percentages_flag $file`))
     end
 end
@@ -297,7 +297,7 @@ default arguments.
 macro pprof(ex)
     esc(quote
         $Profile.@profile $ex
-        $(@__MODULE__).pprof()
+        $pprof()
     end)
 end
 


### PR DESCRIPTION
The original build failure was complaining that `pprof()` cannot be found, and indeed this macro was written a bit weirdly.
https://travis-ci.com/github/JuliaPerf/PProf.jl/jobs/389745011

```
file = "/var/folders/nz/vv4_9tw56nv9k3tkvyszvwg80000gn/T/jl_QLowBp.pb.gz"
@pprof macro: Error During Test at /Users/travis/build/JuliaPerf/PProf.jl/test/PProf.jl:82
  Got exception outside of a @test
  UndefVarError: pprof not defined
  Stacktrace:
    [1] refresh(; webhost::String, webport::Int64, file::String, ui_relative_percentages::Bool)
      @ PProf ~/build/JuliaPerf/PProf.jl/src/PProf.jl:286
    [2] pprof(data::Nothing, period::Nothing; web::Bool, webhost::String, webport::Int64, out::String, from_c::Bool, drop_frames::Nothing, keep_frames::Nothing, ui_relative_percentages::Bool)
      @ PProf ~/build/JuliaPerf/PProf.jl/src/PProf.jl:251
    [3] pprof
      @ ~/build/JuliaPerf/PProf.jl/src/PProf.jl:94 [inlined]
    [4] top-level scope
      @ ~/build/JuliaPerf/PProf.jl/src/PProf.jl:313
    [5] top-level scope
      @ ~/build/JuliaPerf/PProf.jl/test/PProf.jl:84
    [6] top-level scope
      @ /Users/sabae/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1113
    [7] top-level scope
      @ ~/build/JuliaPerf/PProf.jl/test/PProf.jl:84
    [8] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [9] top-level scope
      @ ~/build/JuliaPerf/PProf.jl/test/runtests.jl:4
   [10] top-level scope
      @ /Users/sabae/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1113
   [11] top-level scope
      @ ~/build/JuliaPerf/PProf.jl/test/runtests.jl:4
   [12] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [13] top-level scope
      @ none:6
   [14] eval(m::Module, e::Any)
      @ Core ./boot.jl:360
   [15] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [16] _start()
      @ Base ./client.jl:485
```

i tried simplifying it, in the hopes that would just magically fix it, but now the build is failing on some unrelated(?) PCRE failure during the build step?:
https://travis-ci.com/github/JuliaPerf/PProf.jl/jobs/389738246
```
└ @ Pkg.Types /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/Types.jl:949
    Cloning registry from "https://github.com/JuliaRegistries/General.git"
      Added registry `General` to `~/.julia/registries/General`
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
  Installed OrderedCollections ─ v1.3.1
  Installed pprof_jll ────────── v0.0.0-20191205061153+0
  Installed ProtoBuf ─────────── v0.8.0
ERROR: PCRE JIT error: no more memory
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:33
  [2] jit_compile
    @ ./pcre.jl:138 [inlined]
  [3] compile(regex::Regex)
    @ Base ./regex.jl:73
  [4] Regex(pattern::String, compile_options::UInt32, match_options::UInt32)
    @ Base ./regex.jl:37
  [5] Regex
    @ ./regex.jl:60 [inlined]
  [6] parse(::Type{Base.BinaryPlatforms.Platform}, triplet::String; validate_strict::Bool)
    @ Base.BinaryPlatforms ./binaryplatforms.jl:716
  [7] parse
    @ ./binaryplatforms.jl:713 [inlined]
  [8] HostPlatform
```