### PR TITLE
Add `full_signatures::Bool` arg to print frames with full argument types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PProf"
 uuid = "e4faabce-9ead-11e9-39d9-4379958e3056"
 authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.com>"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -221,18 +221,17 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                 linfo = frame.linfo::Core.MethodInstance
                 meth = linfo.def
                 file = string(meth.file)
-                funcProto.name        = enter!(string(meth.module, ".", meth.name))
-                funcProto.system_name = enter!(string(meth.module, ".", meth.name))
+                funcProto.name       = enter!(string(meth.module, ".", meth.name))
                 funcProto.start_line = convert(Int64, meth.line)
             else
                 # frame.linfo either nothing or CodeInfo, either way fallback
                 file = string(frame.file)
                 funcProto.name = enter!(string(frame.func))
-                funcProto.system_name = enter!(string(frame.func))
                 funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
             end
             file = Base.find_source_file(file)
             funcProto.filename   = enter!(file)
+            funcProto.system_name = funcProto.name
             # Only keep C functions if from_c=true
             if (from_c || !frame.from_c)
                 funcs[func_id] = funcProto

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -221,17 +221,18 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                 linfo = frame.linfo::Core.MethodInstance
                 meth = linfo.def
                 file = string(meth.file)
-                funcProto.name       = enter!(string(meth.module, ".", meth.name))
+                funcProto.name        = enter!(string(meth.module, ".", meth.name))
+                funcProto.system_name = enter!(string(meth.module, ".", meth.name))
                 funcProto.start_line = convert(Int64, meth.line)
             else
                 # frame.linfo either nothing or CodeInfo, either way fallback
                 file = string(frame.file)
                 funcProto.name = enter!(string(frame.func))
+                funcProto.system_name = enter!(string(frame.func))
                 funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
             end
             file = Base.find_source_file(file)
             funcProto.filename   = enter!(file)
-            funcProto.system_name = funcProto.name
             # Only keep C functions if from_c=true
             if (from_c || !frame.from_c)
                 funcs[func_id] = funcProto

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -43,6 +43,7 @@ function pprof(fg::Node{NodeData},
             file = string(meth.file)
             # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
             funcProto.name       = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
+            funcProto.system_name = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
             funcProto.start_line = convert(Int64, meth.line)
         else
             # frame.linfo either nothing or CodeInfo, either way fallback
@@ -51,11 +52,11 @@ function pprof(fg::Node{NodeData},
             # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
             # TODO: Remove this hack after https://github.com/google/pprof/pull/564
             funcProto.name = enter!(repr(string(frame.func))[2:end-1])
+            funcProto.system_name = enter!(repr(string(frame.func))[2:end-1])
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
         end
         file = Base.find_source_file(file)
         funcProto.filename   = enter!(file)
-        funcProto.system_name = funcProto.name
         # Only keep C functions if from_c=true
         if (from_c || !frame.from_c)
             funcs[id] = funcProto

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -43,7 +43,6 @@ function pprof(fg::Node{NodeData},
             file = string(meth.file)
             # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
             funcProto.name       = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
-            funcProto.system_name = enter!(repr(string(meth.module, ".", meth.name))[2:end-1])
             funcProto.start_line = convert(Int64, meth.line)
         else
             # frame.linfo either nothing or CodeInfo, either way fallback
@@ -52,11 +51,11 @@ function pprof(fg::Node{NodeData},
             # HACK: Apparently proto doesn't escape func names with `"` in them ... >.<
             # TODO: Remove this hack after https://github.com/google/pprof/pull/564
             funcProto.name = enter!(repr(string(frame.func))[2:end-1])
-            funcProto.system_name = enter!(repr(string(frame.func))[2:end-1])
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
         end
         file = Base.find_source_file(file)
         funcProto.filename   = enter!(file)
+        funcProto.system_name = funcProto.name
         # Only keep C functions if from_c=true
         if (from_c || !frame.from_c)
             funcs[id] = funcProto

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -39,24 +39,32 @@ function pprof(fg::Node{NodeData},
         funcProto = Function()
         funcProto.id = id
         file = nothing
-        if linfo !== nothing && linfo isa Core.MethodInstance
+        simple_name = _escape_name_for_pprof(frame.func)
+        local full_name_with_args
+        if frame.linfo !== nothing && frame.linfo isa Core.MethodInstance
+            linfo = frame.linfo::Core.MethodInstance
             meth = linfo.def
             file = string(meth.file)
             io = IOBuffer()
             Base.show_tuple_as_call(io, meth.name, linfo.specTypes)
             name = String(take!(io))
-            name = _escape_name_for_pprof(name, full_signatures)
-            funcProto.name       = enter!(name)
-            funcProto.system_name = enter!(_escape_name_for_pprof(name, true))
+            full_name_with_args = _escape_name_for_pprof(name)
             funcProto.start_line = convert(Int64, meth.line)
         else
             # frame.linfo either nothing or CodeInfo, either way fallback
-            # (This could be because we are `from_c`)
             file = string(frame.file)
-            name = _escape_name_for_pprof(string(frame.func), full_signatures)
-            funcProto.name = enter!(name)
-            funcProto.system_name = enter!(_escape_name_for_pprof(name, true))
+            full_name_with_args = _escape_name_for_pprof(string(frame.func))
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
+        end
+        # WEIRD TRICK: By entering a separate copy of the string (with a
+        # different string id) for the name and system_name, pprof will use
+        # the supplied `name` *verbatim*, without pruning off the arguments.
+        # So even when full_signatures == false, we want to generate two `enter!` ids.
+        funcProto.system_name = enter!(simple_name)
+        if full_signatures
+            funcProto.name = enter!(full_name_with_args)
+        else
+            funcProto.name = enter!(simple_name)
         end
         file = Base.find_source_file(file)
         funcProto.filename   = enter!(file)

--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -56,11 +56,12 @@ function pprof(fg::Node{NodeData},
             full_name_with_args = _escape_name_for_pprof(string(frame.func))
             funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
         end
-        # WEIRD TRICK: By entering a separate copy of the string (with a
-        # different string id) for the name and system_name, pprof will use
-        # the supplied `name` *verbatim*, without pruning off the arguments.
-        # So even when full_signatures == false, we want to generate two `enter!` ids.
-        funcProto.system_name = enter!(simple_name)
+        # WEIRD TRICK: By entering a *different value* for the name and system_name, pprof
+        # will use the supplied `name` *verbatim*, without pruning off the arguments. So
+        # even when full_signatures == false, we want to generate two `enter!` ids. So we
+        # achieve that by entering an _empty_ name for the system_name, so that pprof will
+        # use the `name` as provided.
+        funcProto.system_name = enter!("")
         if full_signatures
             funcProto.name = enter!(full_name_with_args)
         else

--- a/test/PProf.jl
+++ b/test/PProf.jl
@@ -84,6 +84,14 @@ end
     end
 end
 
+@testset "full_signatures" begin
+    Profile.clear()
+    @profile foo(1000000, 5, [])
+    @test "foo" in load_prof_proto(pprof(out=tempname(), web=false, full_signatures = false)).string_table
+    @test any(occursin.(Regex("^foo\\(::$Int, ::$Int, ::(Vector|Array)"),
+                load_prof_proto(pprof(out=tempname(), web=false, full_signatures = true)).string_table))
+end
+
 @testset "drop_frames/keep_frames" begin
     @test load_prof_proto(pprof(out=tempname(), web=false, drop_frames = "foo")).drop_frames != 0
     @test load_prof_proto(pprof(out=tempname(), web=false, keep_frames = "foo")).keep_frames != 0


### PR DESCRIPTION
Fixes https://github.com/JuliaPerf/PProf.jl/issues/24

It turns out that (as far as I can tell), setting a separate `Name` and `OriginalName` in the proto is enough to cause `google/pprof` to _not_ modify the user-supplied `Name`.

This PR uses this trick to prevent name mangling in `pprof`, and provides an optional argument to control whether we emit only the generic function name or the full method signature for the given method.