### PR TITLE
Always use the frame name,file,line,linfo as key.

### DIFF
--- a/src/flamegraphs.jl
+++ b/src/flamegraphs.jl
@@ -167,11 +167,13 @@ function pprof(fg::Node{NodeData},
                 locs[id] = location
                 linfo = data.sf.linfo
 
-                func_id = if frame.linfo !== nothing
-                    hash(frame.linfo)
-                else
-                    hash((frame.func, frame.file, frame.line))
-                end
+                # If the function comes with a `linfo` (meaning the profile was generated
+                # in this process), we include it in the hash. If not, it's will be
+                # `nothing`, which is okay to hash.
+                # We include all of these in the hash though because in some contexts (such
+                # as `@snoopi_deep` profiles), two frames with the same `linfo` might have
+                # different func name.
+                func_id = hash((frame.func, frame.file, frame.line, frame.linfo))
 
                 _register_function(funcs, func_id, linfo, frame)
                 push!(location.line, Line(function_id = func_id, line = frame.line))


### PR DESCRIPTION
Some profiles, such as `@snoopi_deep` profiles, set different function
names for the same `linfo`, so it's not safe to always use `linfo` as a
key for the proto maps.

This change always uses the (name,file,line,linfo) tuple as the key for
these frames.