### PR TITLE
Revert "CompatHelper: bump compat for ProtoBuf to 0.11, (keep existing compat)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ pprof_jll = "cf2c5f97-e748-59fa-a03f-dda3c62118cb"
 AbstractTrees = "0.3"
 FlameGraphs = "0.2"
 OrderedCollections = "1.1"
-ProtoBuf = "0.7, 0.8, 0.11"
+ProtoBuf = "0.7, 0.8"
 julia = "1.3"
 pprof_jll = "0.0"
 


### PR DESCRIPTION
Reverts JuliaPerf/PProf.jl#42

Until we adapt to the changes in the Proto.jl package.