### PR TITLE
respect `from_c`; skip Array constructor

### DIFF
--- a/src/allocs_profile.jl
+++ b/src/allocs_profile.jl
@@ -140,7 +140,7 @@ function to_pprof(alloc_profile::Profile.Allocs.AllocResults
         # we also enter that location into the locations table
         location_ids = UInt64[
             maybe_add_location(frame)
-            for frame in sample.stacktrace if (!frame.from_c || from_c) && (frame.func != :Array)
+            for frame in sample.stacktrace if (!frame.from_c || from_c)
         ]
 
         if aggregate_by_type

--- a/src/allocs_profile.jl
+++ b/src/allocs_profile.jl
@@ -93,11 +93,7 @@ function to_pprof(alloc_profile::Profile.Allocs.AllocResults
             (function_name, file_name, line_number) =
                 string(frame.func), string(frame.file), frame.line
 
-            ## Decode the IP into information about this stack frame
-            #if (!from_c && location_from_c)
-            #    continue
-            #end
-
+            # Decode the IP into information about this stack frame
             function_id = get!(funcs_map, function_name) do
                 func_id = UInt64(length(functions) + 1)
 
@@ -143,8 +139,8 @@ function to_pprof(alloc_profile::Profile.Allocs.AllocResults
         # for each location in the sample.stack, if it's the first time seeing it,
         # we also enter that location into the locations table
         location_ids = UInt64[
-            maybe_add_location(location)
-            for location in sample.stacktrace
+            maybe_add_location(frame)
+            for frame in sample.stacktrace if !frame.from_c || from_c
         ]
 
         if aggregate_by_type

--- a/src/allocs_profile.jl
+++ b/src/allocs_profile.jl
@@ -140,7 +140,7 @@ function to_pprof(alloc_profile::Profile.Allocs.AllocResults
         # we also enter that location into the locations table
         location_ids = UInt64[
             maybe_add_location(frame)
-            for frame in sample.stacktrace if !frame.from_c || from_c
+            for frame in sample.stacktrace if (!frame.from_c || from_c) && (frame.func != :Array)
         ]
 
         if aggregate_by_type


### PR DESCRIPTION
Stacked on #46 

~Skipped Array constructor so that there are edges directly from the functions that allocate arrays to the array types.~

EDIT(NHD): I'm going to leave this part out for now; we can always add it back in if we can't figure out a better, more general solution