### PR TITLE
Always add a Type label, even when `frame_for_type=true`, so `Hiding` frames in the web UI doesn't hide the type :)

### DIFF
--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -173,14 +173,11 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
             1,                   # allocs
             sample.size,         # bytes
         ]
-        # TODO: Consider reporting a label? (Dangly thingy)
 
         labels = Label[
             Label(key = enter!("bytes"), num = sample.size, num_unit = enter!("bytes")),
+            Label(key = enter!("type"), str = enter!(_escape_name_for_pprof(string(sample.type))))
         ]
-        if !frame_for_type
-            push!(labels, Label(key = enter!("type"), str = enter!(_escape_name_for_pprof(string(sample.type)))))
-        end
 
         push!(prof.sample, Sample(;location_id = location_ids, value = value, label = labels))
     end


### PR DESCRIPTION
This way, if you hide some frames, you still get to see the types move up as the frames are hidden.

Here's what it looks like now:

Before:
<img width="692" alt="Screen Shot 2022-01-27 at 4 41 34 PM" src="https://user-images.githubusercontent.com/1582097/151448477-f6913bf7-e4d4-4ba4-82df-c9aa5c650412.png">

After hiding some frames up to the `Array` constructor:
<img width="209" alt="Screen Shot 2022-01-27 at 4 42 03 PM" src="https://user-images.githubusercontent.com/1582097/151448529-56d16a10-2cbb-4cc8-a69c-956a55fdab2b.png">
