### PR TITLE
Use `isdefined()` instead of testing `VERSION` for `Profile.Allocs`

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -352,7 +352,7 @@ end
 
 include("flamegraphs.jl")
 
-if VERSION >= v"1.8.0-DEV.1346"  # PR https://github.com/JuliaLang/julia/pull/42768
+if isdefined(Profile, :Allocs)  # PR https://github.com/JuliaLang/julia/pull/42768
     include("Allocs.jl")
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ end
     include("flamegraphs.jl")
 end
 
-if VERSION >= v"1.8.0-DEV.1346"  # PR https://github.com/JuliaLang/julia/pull/42768
+@static if isdefined(Profile, :Allocs)  # PR https://github.com/JuliaLang/julia/pull/42768
 @testset "Allocs.jl" begin
     include("Allocs.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using Profile
 
 @testset "PProf.jl" begin
     include("PProf.jl")
@@ -9,8 +10,7 @@ end
 end
 
 @static if isdefined(Profile, :Allocs)  # PR https://github.com/JuliaLang/julia/pull/42768
-@testset "Allocs.jl" begin
-    include("Allocs.jl")
+    @testset "Allocs.jl" begin
+        include("Allocs.jl")
+    end
 end
-end
-


### PR DESCRIPTION
Use `isdefined()` instead of testing `VERSION` for `Profile.Allocs`

This lets PProf continue to work for custom builds of julia that have
Allocs profiling available, such as if you backport the allocations
profiler to an earlier version of julia