### PR TITLE
add progress bar to allocation preparation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 pprof_jll = "cf2c5f97-e748-59fa-a03f-dda3c62118cb"
 

--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -18,6 +18,8 @@ using Base.StackTraces: StackFrame
 using PProf.ProtoBuf
 using PProf.OrderedCollections
 
+using ProgressMeter
+
 """
 PProf.Allocs.pprof([alloc_profile]; kwargs...)
 
@@ -154,7 +156,8 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
         return maybe_add_location(StackFrame(get_type_name(typename), "nothing", 0))
     end
 
-    for sample in alloc_profile.allocs        # convert the sample.stack to vector of location_ids
+    # convert the sample.stack to vector of location_ids
+    @showprogress "Analyzing $(length(alloc_profile.allocs)) allocation samples..." for sample in alloc_profile.allocs
         # for each location in the sample.stack, if it's the first time seeing it,
         # we also enter that location into the locations table
         location_ids = UInt64[


### PR DESCRIPTION
I ran the allocation profiler with `sample_rate=0.1` and the process of preparing the pprof took >10 minutes with no output before I quit.

This adds a progress meter to the preparation stage.

There's still a long silence before the warning message shows, but I guess that's a `Profile` issue.

```
julia> PProf.Allocs.pprof(from_c = false)
┌ Warning: The allocation profiler is not fully implemented, and may have missed some of the allocs. For more info see https://github.com/JuliaLang/julia/issues/43688
└ @ Profile.Allocs ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.8/Profile/src/Allocs.jl:134
Analyzing 9239305 allocation samples...  1%|▉                                                                                                                       |  ETA: 0:48:08
```

cc. @NHDaly @vilterp 