### PR TITLE
For PProf.Allocs, change the default metric to `allocs`, not `size`.

### DIFF
--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -71,7 +71,10 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
     prof = PProfile(
         sample = [], location = [], _function = [],
         mapping = [], string_table = [],
-        sample_type = sample_type, default_sample_type = 2, # size
+        sample_type = sample_type,
+        # We default to allocs, since the Profile.Allocs code currently uniformly samples
+        # accross allocations, so allocs is a representative profile, while size is not.
+        default_sample_type = 1, # allocs
         period = period, period_type = ValueType!("heap", "bytes")
     )
 


### PR DESCRIPTION
We default to allocs, since julia's Profile.Allocs code currently
uniformly samples accross allocations, so allocs is a representative
profile, while size is not.

Explanation:

If each allocation was uniform (as in the case of the allocs sample
type), then uniformly sampling should give an accurate distribution of
where the allocations occur: code that allocates more often is more
likely to show up in the profile.

But if the metric we're interested in is not uniform: how many bytes are
allocated, uniform sampling will not get us a representative
distribution of where the bytes are allocated! Code that allocates very
large objects is no more or less likely to be included than code that
allocates very small ones.