### PR TITLE
Record a custom (`[unknown function]`) for empty function names

### DIFF
--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -120,6 +120,8 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                     full_name_with_args = _escape_name_for_pprof(string(frame.func))
                     funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
                 end
+                isempty(simple_name) && (simple_name = "[unknown function]")
+                isempty(full_name_with_args) && (full_name_with_args = "[unknown function]")
                 # WEIRD TRICK: By entering a separate copy of the string (with a
                 # different string id) for the name and system_name, pprof will use
                 # the supplied `name` *verbatim*, without pruning off the arguments.

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -239,6 +239,8 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                 full_name_with_args = _escape_name_for_pprof(string(frame.func))
                 funcProto.start_line = convert(Int64, frame.line) # TODO: Get start_line properly
             end
+            isempty(simple_name) && (simple_name = "[unknown function]")
+            isempty(full_name_with_args) && (full_name_with_args = "[unknown function]")
             # WEIRD TRICK: By entering a separate copy of the string (with a
             # different string id) for the name and system_name, pprof will use
             # the supplied `name` *verbatim*, without pruning off the arguments.


### PR DESCRIPTION
In the current code, we just emit an empty name, which pprof
automatically renders as `<unknown>`, but you cannot
search/select/filter on <unknown>, so we need to give those a proper
name that users can then interact with.

This just renames these to `[unknown function]` so that users can select
and filter it.

<img width="342" alt="Screen Shot 2022-02-16 at 9 35 26 AM" src="https://user-images.githubusercontent.com/1582097/154286724-4c4cb8b5-bc0b-47c5-9c99-3836d94fa27c.png">
