### PR TITLE
Exclude new metadata from profiler on 1.8+

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -103,7 +103,11 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                ui_relative_percentages::Bool = true,
             )
     if data === nothing
-        data = copy(Profile.fetch())
+        data = if isdefined(Profile, :has_meta)
+            copy(Profile.fetch(include_meta = false))
+         else
+            copy(Profile.fetch())
+         end
     end
     lookup = lidict
     if lookup === nothing


### PR DESCRIPTION
The metadata occupies samples so needs to be excluded if you're not handling it.