### PR TITLE
Add Allocs example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pprof()
 
 This prints a link to a local webserver where you can inspect the profile you've collected. It produces a file called `profile.pb.gz` in the [`pprof`](https://github.com/google/pprof) format, and then opens the `pprof` tool in interactive "web" mode.
 
-To profile allocations instead of CPU time, simply use the equivalent functions from the `Allocs` submodules instead:
+To profile allocations instead of CPU time, simply use the equivalent functions from the `Allocs` submodule instead:
 ```julia
 # Collect an allocation profile
 Profile.Allocs.clear()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # PProf.jl
-
-[![Build Status](https://travis-ci.com/vchuravy/PProf.jl.svg?branch=master)](https://travis-ci.com/vchuravy/PProf.jl)
-
+[![CI][ci-img]][ci-url]
 
 *Sometimes I need a hammer, sometimes I need a drill, this is a hammer-drill*
 
@@ -75,3 +73,6 @@ Serving web UI on http://localhost:57599
 <img width=500px src="docs/graph.png" alt="graph"/>
 
 <img width=500px src="docs/flamegraph.png" alt="flamegraph"/>
+
+[ci-img]: https://github.com/JuliaPerf/PProf.jl/actions/workflows/CI.yml/badge.svg?branch=master
+[ci-url]: https://github.com/JuliaPerf/PProf.jl/actions/workflows/CI.yml

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 using Profile
 using PProf
 
-# collect a profile
+# Collect a profile
+Profile.clear()
 @profile peakflops()
 
 # Export pprof profile and open interactive profiling web interface.
@@ -17,6 +18,16 @@ pprof()
 ```
 
 This prints a link to a local webserver where you can inspect the profile you've collected. It produces a file called `profile.pb.gz` in the [`pprof`](https://github.com/google/pprof) format, and then opens the `pprof` tool in interactive "web" mode.
+
+To profile allocations instead of CPU time, simply use the equivalent functions from the `Allocs` submodules instead:
+```julia
+# Collect an allocation profile
+Profile.Allocs.clear()
+Profile.Allocs.@profile peakflops()
+
+# Export pprof allocation profile and open interactive profiling web interface.
+PProf.Allocs.pprof()
+```
 
 For more usage examples see the pprof docs: https://github.com/google/pprof/blob/master/doc/README.md
 


### PR DESCRIPTION
People often complain that Julia doesn't have enough tools for tracking down allocations. This package, together with Profile.Allocs, actually seems pretty great for that to me though -- but you might not be able to figure out how from a casual glance at the README without watching the JuliaCon talk.

This PR adds a simple allocation profiling example that mirrors the top-line cpu profiling example just above it in the README.

This PR also updates the readme CI badge to point to the current github actions CI instead of the old Travis.