### PR TITLE
Add options to filter out internal GC and dispatch frames

### DIFF
--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -28,10 +28,10 @@ The `kwargs` are the same as [`PProf.pprof`](@ref), except:
   of every allocation. Note that this tends to make the Graph view harder to
   read, because it's over-aggregated, so we recommend filtering out the `Type:`
   nodes in the PProf web UI.
-- `skip_gc_internal_frames::Bool = true`: By default, we hide the tail-end of the
+- `skip_gc_internal::Bool = true`: By default, we hide the tail-end of the
   stacktrace because it's not very useful. *Every* frame ends with some `jl_gc_*_alloc`,
   which calls `maybe_record_alloc_to_profile`, which is distracting in Profile viewer.
-  This is similar to `skip_julia_dispatch_frames` in the default CPU pprof() function.
+  This is similar to `skip_jl_dispatch` in the default CPU pprof() function.
 """
 function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch()
                ;
@@ -44,9 +44,9 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                keep_frames::Union{Nothing, AbstractString} = nothing,
                ui_relative_percentages::Bool = true,
                full_signatures::Bool = true,
-               skip_julia_dispatch_frames::Bool = false,
+               skip_jl_dispatch::Bool = false,
                # Allocs-specific arguments:
-               skip_gc_internal_frames::Bool = true,
+               skip_gc_internal::Bool = true,
                frame_for_type::Bool = true,
             )
     period = UInt64(0x1)
@@ -132,8 +132,8 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                 isempty(simple_name) && (simple_name = "[unknown function]")
                 isempty(full_name_with_args) && (full_name_with_args = "[unknown function]")
 
-                if !PProf.should_keep_frame(from_c, skip_julia_dispatch_frames,
-                        skip_gc_internal_frames, frame, simple_name)
+                if !PProf.should_keep_frame(from_c, skip_jl_dispatch,
+                        skip_gc_internal, frame, simple_name)
                     success[] = false
                     push!(funcs_to_skip, function_key)
                     return 0

--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -49,6 +49,7 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                skip_gc_internal::Bool = true,
                frame_for_type::Bool = true,
             )
+    PProf.log_greeting(skip_jl_dispatch)
     period = UInt64(0x1)
 
     @assert !isempty(basename(out)) "`out=` must specify a file path to write to. Got unexpected: '$out'"

--- a/src/Allocs.jl
+++ b/src/Allocs.jl
@@ -28,6 +28,10 @@ The `kwargs` are the same as [`PProf.pprof`](@ref), except:
   of every allocation. Note that this tends to make the Graph view harder to
   read, because it's over-aggregated, so we recommend filtering out the `Type:`
   nodes in the PProf web UI.
+- `skip_gc_internal_frames::Bool = true`: By default, we hide the tail-end of the
+  stacktrace because it's not very useful. *Every* frame ends with some `jl_gc_*_alloc`,
+  which calls `maybe_record_alloc_to_profile`, which is distracting in Profile viewer.
+  This is similar to `skip_julia_dispatch_frames` in the default CPU pprof() function.
 """
 function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch()
                ;
@@ -40,7 +44,9 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                keep_frames::Union{Nothing, AbstractString} = nothing,
                ui_relative_percentages::Bool = true,
                full_signatures::Bool = true,
+               skip_julia_dispatch_frames::Bool = false,
                # Allocs-specific arguments:
+               skip_gc_internal_frames::Bool = true,
                frame_for_type::Bool = true,
             )
     period = UInt64(0x1)
@@ -63,6 +69,7 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
     # specializations to PProf Functions. We use a hash of the function for the key.
     funcs_map  = Dict{UInt64, UInt64}()
     functions = Vector{Function}()
+    funcs_to_skip = Set{Any}()
 
     # NOTE: It's a bug to use the actual StackFrame itself as a key in a dictionary, since
     # different StackFrames can compare the same sometimes! 🙀 So we manually compute an ID
@@ -80,22 +87,25 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
     drop_frames = isnothing(drop_frames) ? 0 : enter!(drop_frames)
     keep_frames = isnothing(keep_frames) ? 0 : enter!(keep_frames)
 
-    function maybe_add_location(frame::StackFrame)::UInt64
+    function maybe_add_location(frame::StackFrame)::Tuple{Bool,UInt64}
+        # Use a unique function id for the frame:
         # See: https://github.com/JuliaPerf/PProf.jl/issues/69
         function_key = method_instance_id(frame)
         line_number = frame.line
+
+        function_key in funcs_to_skip && return false, 0
+
         # For allocations profile, we uniquely identify each frame position by
         # (function,line_number) pairs. That identifies a position in the code.
         frame_key = (function_key, line_number)
-        return get!(locs_map, frame_key) do
+
+        success = Ref(true)
+        loc = get!(locs_map, frame_key) do
             loc_id = UInt64(length(locations) + 1)
 
             # Extract info from the location frame
             (function_name, file_name) =
                 string(frame.func), string(frame.file)
-
-            # Use a unique function id for the frame:
-            function_key = method_instance_id(frame)
 
             # Decode the IP into information about this stack frame
             function_id = get!(funcs_map, function_key) do
@@ -121,6 +131,14 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                 end
                 isempty(simple_name) && (simple_name = "[unknown function]")
                 isempty(full_name_with_args) && (full_name_with_args = "[unknown function]")
+
+                if !PProf.should_keep_frame(from_c, skip_julia_dispatch_frames,
+                        skip_gc_internal_frames, frame, simple_name)
+                    success[] = false
+                    push!(funcs_to_skip, function_key)
+                    return 0
+                end
+
                 # WEIRD TRICK: By entering a separate copy of the string (with a
                 # different string id) for the name and system_name, pprof will use
                 # the supplied `name` *verbatim*, without pruning off the arguments.
@@ -131,12 +149,17 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
                 else
                     name = enter!(simple_name)
                 end
+
                 file = Base.find_source_file(file_name)
                 file = file !== nothing ? file : file_name
                 filename   = enter!(file)
                 push!(functions, Function(func_id, name, system_name, filename, start_line))
 
                 return func_id
+            end
+
+            if !success[]
+                return 0
             end
 
             push!(
@@ -146,6 +169,8 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
 
             return loc_id
         end
+
+        return success[], loc
     end
 
     type_name_cache = Dict{Any,String}()
@@ -158,17 +183,21 @@ function pprof(alloc_profile::Profile.Allocs.AllocResults = Profile.Allocs.fetch
 
     function construct_location_for_type(typename)
         # TODO: Lol something less hacky than this:
-        return maybe_add_location(StackFrame(get_type_name(typename), "nothing", 0))
+        _, loc = maybe_add_location(StackFrame(get_type_name(typename), "nothing", 0))
+        return loc
     end
 
     # convert the sample.stack to vector of location_ids
     @showprogress "Analyzing $(length(alloc_profile.allocs)) allocation samples..." for sample in alloc_profile.allocs
         # for each location in the sample.stack, if it's the first time seeing it,
         # we also enter that location into the locations table
-        location_ids = UInt64[
-            maybe_add_location(frame)
-            for frame in sample.stacktrace if (!frame.from_c || from_c)
-        ]
+        location_ids = sizehint!(UInt64[], length(sample.stacktrace))
+        for frame in sample.stacktrace
+            should_add, loc = maybe_add_location(frame)
+            if should_add
+                push!(location_ids, loc)
+            end
+        end
 
         if frame_for_type
             # Add location_id for the type:

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -81,13 +81,13 @@ You can also use `PProf.refresh(file="...")` to open a new file in the server.
 - `keep_frames`: frames with function_name fully matching regexp string will be kept, even if it matches drop_functions.
 - `ui_relative_percentages`: Passes `-relative_percentages` to pprof. Causes nodes
   ignored/hidden through the web UI to be ignored from totals when computing percentages.
-- `skip_julia_dispatch_frames::Bool = false`: If true, we hide the internal frames from
+- `skip_jl_dispatch::Bool = false`: If true, we hide the internal frames from
   julia dynamic dispatch: `jl_apply_generic`, `jl_apply`, `jl_invoke`, etc. This helps a lot
   in the Graph view, because otherwise they imply a false recursion in your program when
   there are multiple dynamic dispatches in your stacktrace. However, the dispatches can be
   very useful in the flamegraph view, since they often represent performance problems. So
   consider switching this based on which pprof UI view you're using.
-- `skip_gc_internal_frames::Bool = false`: Provided for consistency with PProf.Alloc.pprof().
+- `skip_gc_internal::Bool = false`: Provided for consistency with PProf.Alloc.pprof().
   True by default, since this would only be present when running an Alloc profile at the
   same time, and you may want to know the impact of that on your CPU profile. See
   [`PProf.Alloc.pprof`](@ref).
@@ -104,8 +104,8 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
                drop_frames::Union{Nothing, AbstractString} = nothing,
                keep_frames::Union{Nothing, AbstractString} = nothing,
                ui_relative_percentages::Bool = true,
-               skip_julia_dispatch_frames::Bool = false,
-               skip_gc_internal_frames::Bool = false,
+               skip_jl_dispatch::Bool = false,
+               skip_gc_internal::Bool = false,
             )
     if data === nothing
         data = if isdefined(Profile, :has_meta)
@@ -239,8 +239,8 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
             isempty(full_name_with_args) && (full_name_with_args = "[unknown function]")
 
             # Only keep C functions if from_c=true, and it's not a skipped internal frame.
-            if !should_keep_frame(from_c, skip_julia_dispatch_frames,
-                    skip_gc_internal_frames, frame, simple_name)
+            if !should_keep_frame(from_c, skip_jl_dispatch,
+                    skip_gc_internal, frame, simple_name)
                 push!(funcs_to_skip, func_id)
                 continue
             end

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -300,9 +300,9 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
     out
 end
 
-log_once::Bool = false
+log_once = false
 function log_greeting(skip_jl_dispatch)
-    if !log_once
+    if !(log_once::Bool)
         global log_once = true
         if !skip_jl_dispatch
             @info """👋  Welcome to PProf!

--- a/test/Allocs.jl
+++ b/test/Allocs.jl
@@ -12,8 +12,8 @@ const out = tempname()
     Profile.Allocs.clear()
     Profile.Allocs.@profile sample_rate=1.0 begin
         # Profile compilation
-        @eval foo(x,y) = x * y + y / x
-        @eval foo(2, 3)
+        @eval $(Symbol("foo_alloc$i"))(x,y) = x * y + x / y
+        @eval $(Symbol("foo_alloc$i"))($i,3)
     end
 
     # Write the profile

--- a/test/Allocs.jl
+++ b/test/Allocs.jl
@@ -68,21 +68,21 @@ function load_prof_proto(file)
     open(io->decode(ProtoDecoder(io), PProf.perftools.profiles.Profile), file, "r")
 end
 
-@testset "skip_julia_dispatch_frames" begin
+@testset "skip_jl_dispatch" begin
     Profile.Allocs.clear();
     Profile.Allocs.@profile sample_rate=1 Base.inferencebarrier(foo)(1)
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_julia_dispatch_frames=false)))
-    @test !matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_julia_dispatch_frames=true)))
+    @test matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=false)))
+    @test !matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=true)))
 end
-@testset "skip_gc_internal_frames" begin
+@testset "skip_gc_internal" begin
     Profile.Allocs.clear();
     Profile.Allocs.@profile sample_rate=1 Base.inferencebarrier(foo)(1)
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal_frames=false)))
-    @test !matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal_frames=true)))
+    @test matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=false)))
+    @test !matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=true)))
 end
 
 

--- a/test/Allocs.jl
+++ b/test/Allocs.jl
@@ -87,8 +87,8 @@ end
 
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches("maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=false)))
-    @test !matches("maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=true)))
+    @test matches(r"jl_gc_.*alloc", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=false)))
+    @test !matches(r"jl_gc_.*alloc", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=true)))
 end
 
 

--- a/test/Allocs.jl
+++ b/test/Allocs.jl
@@ -12,8 +12,8 @@ const out = tempname()
     Profile.Allocs.clear()
     Profile.Allocs.@profile sample_rate=1.0 begin
         # Profile compilation
-        @eval $(Symbol("foo_alloc$i"))(x,y) = x * y + x / y
-        @eval $(Symbol("foo_alloc$i"))($i,3)
+        @eval foo_alloc(x,y) = x * y + x / y
+        @eval foo_alloc(1,3)
     end
 
     # Write the profile
@@ -71,18 +71,24 @@ end
 @testset "skip_jl_dispatch" begin
     Profile.Allocs.clear();
     Profile.Allocs.@profile sample_rate=1 Base.inferencebarrier(foo)(1)
+
+    @assert length(Profile.Allocs.fetch().allocs) > 0
+
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=false)))
-    @test !matches(r"jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=true)))
+    @test matches("jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=false)))
+    @test !matches("jl_apply_generic", load_prof_proto(PProf.Allocs.pprof(;args..., skip_jl_dispatch=true)))
 end
 @testset "skip_gc_internal" begin
     Profile.Allocs.clear();
     Profile.Allocs.@profile sample_rate=1 Base.inferencebarrier(foo)(1)
+
+    @assert length(Profile.Allocs.fetch().allocs) > 0
+
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=false)))
-    @test !matches(r"maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=true)))
+    @test matches("maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=false)))
+    @test !matches("maybe_record_alloc_to_profile", load_prof_proto(PProf.Allocs.pprof(;args..., skip_gc_internal=true)))
 end
 
 

--- a/test/PProf.jl
+++ b/test/PProf.jl
@@ -98,13 +98,13 @@ end
     @test load_prof_proto(pprof(out=tempname(), web=false, keep_frames = "foo")).keep_frames != 0
 end
 
-@testset "skip_julia_dispatch_frames" begin
+@testset "skip_jl_dispatch" begin
     Profile.clear()
     @profile Base.inferencebarrier(foo)(1000000, 5, [])
     args = (; out=tempname(), web=false)
     matches(r, proto) = any(s->occursin(r, s), proto.string_table)
-    @test matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_julia_dispatch_frames=false)))
-    @test !matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_julia_dispatch_frames=true)))
+    @test matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_jl_dispatch=false)))
+    @test !matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_jl_dispatch=true)))
 end
 
 @testset "@pprof macro" begin

--- a/test/PProf.jl
+++ b/test/PProf.jl
@@ -28,8 +28,8 @@ end
 
     @profile for i in 1:10000
         # Profile compilation
-        @eval foo(x,y) = x * y + x / y
-        @eval foo($i,3)
+        @eval $(Symbol("foo$i"))(x,y) = x * y + x / y
+        @eval $(Symbol("foo$i"))($i,3)
     end
 
     # Cache profile output to test that it isn't changed
@@ -96,6 +96,15 @@ end
 @testset "drop_frames/keep_frames" begin
     @test load_prof_proto(pprof(out=tempname(), web=false, drop_frames = "foo")).drop_frames != 0
     @test load_prof_proto(pprof(out=tempname(), web=false, keep_frames = "foo")).keep_frames != 0
+end
+
+@testset "skip_julia_dispatch_frames" begin
+    Profile.clear()
+    @profile Base.inferencebarrier(foo)(1000000, 5, [])
+    args = (; out=tempname(), web=false)
+    matches(r, proto) = any(s->occursin(r, s), proto.string_table)
+    @test matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_julia_dispatch_frames=false)))
+    @test !matches(r"jl_apply_generic", load_prof_proto(pprof(;args..., skip_julia_dispatch_frames=true)))
 end
 
 @testset "@pprof macro" begin


### PR DESCRIPTION
The GC frames are skipped by default now, since they make the GC graphs much less readable, and everyone basically always wants them skipped.

I also refactored things a bit in the process, to allow for only checking these once per frame, and caching the result.

This gives nicer graphs like this one, where the recursion here is _real_ - this is a profile of julia's inference:
<img width="745" alt="Screenshot 2023-07-29 at 10 31 55 PM" src="https://github.com/JuliaPerf/PProf.jl/assets/1582097/4b3740ad-3336-4180-b256-4a49a5a05b4e">

or this one:
<img width="431" alt="Screenshot 2023-07-29 at 10 35 32 PM" src="https://github.com/JuliaPerf/PProf.jl/assets/1582097/d586552e-551f-444b-911d-2a5a722baf44">


I also added this message to tell you about the new flags
<img width="687" alt="Screenshot 2023-07-29 at 11 04 36 PM" src="https://github.com/JuliaPerf/PProf.jl/assets/1582097/19922af8-1ff1-443b-a738-71398354792a">
