### PR TITLE
Fixes #93

### DIFF
--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -275,9 +275,9 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
             file = Base.find_source_file(file)
             filename = enter!(file)
             # Only keep C functions if from_c=true
-            if (from_c || !frame.from_c)
+            #if (from_c || !location_from_c)
                 funcs[func_id] = Function(func_id, name, system_name, filename, start_line)
-            end
+            #end
         end
         locs_from_c[ip] = location_from_c
         # Only keep C frames if from_c=true

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -189,7 +189,7 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
             ]
             idx -= (Profile.nmeta + 2)  # skip all the metas, plus the 2 nulls that end a block.
             continue
-        elseif !has_meta && data[idx] == 0
+        elseif data[idx] == 0
             # Avoid creating empty samples
             # ip == 0x0 is the sentinel value for finishing a backtrace (when meta is disabled), therefore finising a sample
             # On some platforms, we sometimes get two 0s in a row for some reason...


### PR DESCRIPTION
Hi!

I'm not entirely familiar with the pprof format but I stepped through the code after being affected by #93 and this seems to fix that. In addition, when running with `from_c=false` some referenced functions are not inserted into the function list, breaking the parser. This fixes that as well.