### PR TITLE
make thread_sleeping definition a bit more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PProf"
 uuid = "e4faabce-9ead-11e9-39d9-4379958e3056"
 authors = ["Valentin Churavy <v.churavy@gmail.com>", "Nathan Daly <nhdaly@gmail.com>"]
-version = "3.1.2"
+version = "3.1.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/PProf.jl
+++ b/src/PProf.jl
@@ -182,7 +182,7 @@ function pprof(data::Union{Nothing, Vector{UInt}} = nothing,
             threadid = data[idx - Profile.META_OFFSET_THREADID]
 
             meta = Label[
-                Label!("thread_sleeping", thread_sleeping != 0),
+                Label!("thread_sleeping", thread_sleeping == 1),
                 Label!("cycle_clock", cpu_cycle_clock, "nanoseconds"),
                 Label!("taskid", taskid),
                 Label!("threadid", threadid),


### PR DESCRIPTION
We may want to use states such as 2, 3, 4, ... for other things in the profiler.

Let's be more specific about the fact that the `thread_sleeping` state corresponds to 1.

See discussion in https://github.com/JuliaLang/julia/pull/55889#discussion_r1783295919.